### PR TITLE
add heroku app to allowed host in settings

### DIFF
--- a/djangoplayground/settings.py
+++ b/djangoplayground/settings.py
@@ -32,7 +32,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = 'DEBUG' in os.environ
 
-ALLOWED_HOSTS = ['.herokuapp.com']
+ALLOWED_HOSTS = ['django-collaboration-f0d5771cb07e.herokuapp.com']
 
 
 # Application definition


### PR DESCRIPTION
I have updated allowed hosts in the settings.py to include the Heroku app to enable successful deployment